### PR TITLE
Pending intents require mutability flag.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,7 @@ dependencies {
         lifecycle_version = "2.2.0"
         arch_version = "2.1.0"
         material_version = "1.1.0"
-        room_version = "2.2.5"
+        room_version = "2.3.0"
         paging_version = "2.1.2"
         uiautomator_version = "2.2.0"
         work_version = "2.3.4"

--- a/app/opentracesdk_fat/build.gradle
+++ b/app/opentracesdk_fat/build.gradle
@@ -29,7 +29,7 @@ android {
 dependencies {
     ext {
         lifecycle_version = "2.2.0"
-        room_version = "2.2.5"
+        room_version = "2.3.0"
         core_version = "1.2.0"
     }
     implementation fileTree(dir: "libs", include: ["*.jar"])
@@ -57,4 +57,17 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
 
     implementation "androidx.core:core-ktx:$core_version"
+}
+
+allprojects {
+    repositories {
+        // ...
+    }
+
+    // ADD THE FOLLOWING
+    configurations.all {
+        resolutionStrategy {
+            force 'org.xerial:sqlite-jdbc:3.34.0'
+        }
+    }
 }

--- a/app/opentracesdk_fat/src/main/java/ai/kun/opentracesdk_fat/alarm/BLEClient.kt
+++ b/app/opentracesdk_fat/src/main/java/ai/kun/opentracesdk_fat/alarm/BLEClient.kt
@@ -15,6 +15,7 @@ import android.bluetooth.le.*
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.PowerManager
 import android.util.Log
 import androidx.core.app.AlarmManagerCompat
@@ -84,11 +85,18 @@ class BLEClient : BroadcastReceiver() {
         val intent = Intent(context, BLEClient::class.java)
         intent.putExtra(INTERVAL_KEY, interval)
         intent.putExtra(ISREACTNATIVE_KEY, BLETrace.isReactNative)
+        var flag = 0
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ) {
+            flag = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            flag = PendingIntent.FLAG_UPDATE_CURRENT
+        }
+
         return PendingIntent.getBroadcast(
             context,
             CLIENT_REQUEST_CODE,
             intent,
-            PendingIntent.FLAG_UPDATE_CURRENT
+            flag
         )
     }
 

--- a/app/opentracesdk_fat/src/main/java/ai/kun/opentracesdk_fat/alarm/BLEServer.kt
+++ b/app/opentracesdk_fat/src/main/java/ai/kun/opentracesdk_fat/alarm/BLEServer.kt
@@ -16,6 +16,7 @@ import android.bluetooth.le.AdvertiseSettings
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.ParcelUuid
 import android.os.PowerManager
 import android.util.Log
@@ -89,7 +90,13 @@ class BLEServer : BroadcastReceiver(), GattServerActionListener  {
         val intent = Intent(context, BLEServer::class.java)
         intent.putExtra(INTERVAL_KEY, interval)
         intent.putExtra(ISREACTNATIVE_KEY, BLETrace.isReactNative)
-        return PendingIntent.getBroadcast(context, SERVER_REQUEST_CODE, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+        var flag = 0
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ) {
+            flag = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            flag = PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        return PendingIntent.getBroadcast(context, SERVER_REQUEST_CODE, intent, flag)
     }
 
 

--- a/app/opentracesdk_fat/src/main/java/ai/kun/opentracesdk_fat/util/NotificationUtils.kt
+++ b/app/opentracesdk_fat/src/main/java/ai/kun/opentracesdk_fat/util/NotificationUtils.kt
@@ -160,9 +160,15 @@ object NotificationUtils {
         // is clicked.
         //TODO: replace hard coded class string with an extra passed to alarm manager
         val notificationIntent = Intent(context, Class.forName("ai.kun.socialdistancealarm.MainActivity"))
+        var flag = 0
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ) {
+            flag = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            flag = PendingIntent.FLAG_UPDATE_CURRENT
+        }
         val notificationPendingIntent = PendingIntent.getActivity(
             context, NOTIFICATION_ID, notificationIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT
+            flag
         )
 
         // Build the notification with all of the parameters.


### PR DESCRIPTION
In order to support Android 31 any pending intent needs to specify mutability as seen in the link below. 

https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability

Other changes were made to be able to run a gradle build to build the opentracesdk_fat.release.aar